### PR TITLE
Replace llbase with llsd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 coverage.xml
 .coverage
 .tox/
+.venv/
 build/

--- a/git_hooks/llsd.py
+++ b/git_hooks/llsd.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import argparse
 import xml.sax.handler
 
-from llbase import llsd
+import llsd
 
 from .util import eprint
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    llbase
+    llsd
 
 [options.packages.find]
 exclude = tests*


### PR DESCRIPTION
Adopt our new standalone [llsd ](https://github.com/secondlife/python-llsd) library.