### PR TITLE
Fix git-hooks/coding_policy_git.py on Windows TC hosts

### DIFF
--- a/coding_policy_git.py
+++ b/coding_policy_git.py
@@ -532,7 +532,7 @@ if __name__ == "__main__":
                                    encoding='utf8', check=True,
                                    stdout=subprocess.PIPE).stdout.rstrip()
         print(f'Fixing cygwin {rootdir} to {rootfixed}')
-        rootdir = rootfixed
+        rootdir = Path(rootfixed)
     repo = Repo(str(rootdir))
 
     ui = checker_ui()


### PR DESCRIPTION
Our `git-hooks/coding_policy_git.py` never worked on Windows TC hosts. Rather than digging in, we simply disabled the coding policy check on Windows hosts and left it that way for years. The change below works around the problem: it seems gitpython's `git.Git.rev_parse('--show-toplevel')` is baffled by cygwin paths.

An example run is [here](https://teamcity.secondlife.io/buildConfiguration/SLing_Viewer_Viewer_ViewerW64/1052593?showRootCauses=false&expandBuildProblemsSection=true), which failed _because_ the coding policy checks ran and -- having been dormant for years -- diagnosed a number of coding policy violations.